### PR TITLE
fix: add navigation after successful login/signup

### DIFF
--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -20,7 +20,11 @@ export default function SignIn() {
   const router = useRouter();
 
   const handleLogin = async () => {
-    if (isLoading) return;
+    if (!email || !password) {
+      Alert.alert("Validation Error", "Please fill in all fields");
+      return;
+    }
+
     setIsLoading(true);
 
     try {
@@ -82,9 +86,7 @@ export default function SignIn() {
             activeOpacity={0.7}
             disabled={isLoading}
           >
-            <Text style={styles.submitButtonText}>
-              {isLoading ? "Signing In..." : "Sign In"}
-            </Text>
+            <Text style={styles.submitButtonText}>Sign In</Text>
           </TouchableOpacity>
         </View>
         <View style={styles.signUpPrompt}>

--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -7,6 +7,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   TouchableOpacity,
+  Alert,
 } from "react-native";
 import { theme, sharedStyles } from "@/utils/theme";
 import { authClient } from "@/auth-client";
@@ -15,13 +16,30 @@ import { useRouter } from "expo-router";
 export default function SignIn() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
   const handleLogin = async () => {
-    await authClient.signIn.email({
-      email,
-      password,
-    });
+    if (isLoading) return;
+    setIsLoading(true);
+
+    try {
+      const result = await authClient.signIn.email({
+        email,
+        password,
+      });
+
+      if (result.error) {
+        Alert.alert("Login Failed", result.error.message || "Please try again");
+        return;
+      }
+
+      router.replace("/");
+    } catch (error) {
+      Alert.alert("Error", "An unexpected error occurred");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -59,11 +77,14 @@ export default function SignIn() {
         </View>
         <View style={styles.buttonRow}>
           <TouchableOpacity
-            style={styles.submitButton}
+            style={[styles.submitButton, isLoading && styles.submitButtonDisabled]}
             onPress={handleLogin}
             activeOpacity={0.7}
+            disabled={isLoading}
           >
-            <Text style={styles.submitButtonText}>Sign In</Text>
+            <Text style={styles.submitButtonText}>
+              {isLoading ? "Signing In..." : "Sign In"}
+            </Text>
           </TouchableOpacity>
         </View>
         <View style={styles.signUpPrompt}>

--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -7,21 +7,41 @@ import {
   KeyboardAvoidingView,
   Platform,
   TouchableOpacity,
+  Alert,
 } from "react-native";
 import { authClient } from "../auth-client";
 import { theme, sharedStyles } from "@/utils/theme";
+import { useRouter } from "expo-router";
 
 export default function App() {
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
 
-  const handleLogin = async () => {
-    await authClient.signUp.email({
-      email,
-      password,
-      name,
-    });
+  const handleSignUp = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+
+    try {
+      const result = await authClient.signUp.email({
+        email,
+        password,
+        name,
+      });
+
+      if (result.error) {
+        Alert.alert("Sign Up Failed", result.error.message || "Please try again");
+        return;
+      }
+
+      router.replace("/");
+    } catch (error) {
+      Alert.alert("Error", "An unexpected error occurred");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -71,11 +91,14 @@ export default function App() {
         </View>
         <View style={styles.buttonRow}>
           <TouchableOpacity
-            style={styles.submitButton}
-            onPress={handleLogin}
+            style={[styles.submitButton, isLoading && styles.submitButtonDisabled]}
+            onPress={handleSignUp}
             activeOpacity={0.7}
+            disabled={isLoading}
           >
-            <Text style={styles.submitButtonText}>Sign Up</Text>
+            <Text style={styles.submitButtonText}>
+              {isLoading ? "Signing Up..." : "Sign Up"}
+            </Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/app/sign-up.tsx
+++ b/app/sign-up.tsx
@@ -13,7 +13,7 @@ import { authClient } from "../auth-client";
 import { theme, sharedStyles } from "@/utils/theme";
 import { useRouter } from "expo-router";
 
-export default function App() {
+export default function SignUp() {
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
@@ -21,7 +21,11 @@ export default function App() {
   const router = useRouter();
 
   const handleSignUp = async () => {
-    if (isLoading) return;
+    if (!name || !email || !password) {
+      Alert.alert("Validation Error", "Please fill in all fields");
+      return;
+    }
+
     setIsLoading(true);
 
     try {
@@ -96,9 +100,7 @@ export default function App() {
             activeOpacity={0.7}
             disabled={isLoading}
           >
-            <Text style={styles.submitButtonText}>
-              {isLoading ? "Signing Up..." : "Sign Up"}
-            </Text>
+            <Text style={styles.submitButtonText}>Sign Up</Text>
           </TouchableOpacity>
         </View>
       </View>


### PR DESCRIPTION
## Summary
- Fixes the issue where users stay on the sign-in/sign-up screen after successful authentication
- Adds proper error handling for failed login/signup attempts
- Adds loading state to prevent double-submit

## Changes
- `app/sign-in.tsx`: Add navigation, error handling, and loading state
- `app/sign-up.tsx`: Add navigation, error handling, and loading state

## Test plan
- [x] Sign in with valid credentials → navigates to dashboard
- [x] Sign in with invalid credentials → shows error alert
- [x] Sign up with valid info → navigates to dashboard
- [x] Button disabled while loading

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)